### PR TITLE
Backend/studyroom enter->staging: 스터디방 입장 API 및 연동

### DIFF
--- a/backend/src/main/java/com/study/deposit/domain/point/domain/PaymentType.java
+++ b/backend/src/main/java/com/study/deposit/domain/point/domain/PaymentType.java
@@ -1,5 +1,5 @@
 package com.study.deposit.domain.point.domain;
 
 public enum PaymentType {
-    CHARGE,PURCHASE
+    CHARGE, DEPOSIT
 }

--- a/backend/src/main/java/com/study/deposit/domain/studyRoom/controller/StudyRoomController.java
+++ b/backend/src/main/java/com/study/deposit/domain/studyRoom/controller/StudyRoomController.java
@@ -61,7 +61,7 @@ public class StudyRoomController {
             + "추후 Pageable가능성 고려")
     @ApiResponses(
             value = {
-                    @ApiResponse(responseCode = "200", description = "정상 생성"),
+                    @ApiResponse(responseCode = "200", description = "정상 처리"),
                     @ApiResponse(responseCode = "401", description = "사용자 확인 불가"),
             }
     )
@@ -71,6 +71,21 @@ public class StudyRoomController {
                 .status(HttpStatus.OK)
                 .body(CommonResponse.toResponse(CommonCode.OK,studyRoomService.getStudyRoomList()));
     }
+
+//    @Operation(summary = "스터디방 입장 api", description = "스터디방 입장시 요청하는 API")
+//    @ApiResponses(
+//            value = {
+//                    @ApiResponse(responseCode = "200", description = "정상 처리"),
+//                    @ApiResponse(responseCode = "401", description = "사용자 확인 불가"),
+//                    @ApiResponse(responseCode = "402", description = "방 입장을 위한 포인트 부족"),
+//            }
+//    )
+//    @GetMapping
+//    public ResponseEntity<CommonResponse> enterStudyRoom() {
+//        return ResponseEntity
+//                .status(HttpStatus.OK)
+//                .body(CommonResponse.toResponse(CommonCode.OK,studyRoomService.getStudyRoomList()));
+//    }
 
 
 }

--- a/backend/src/main/java/com/study/deposit/domain/studyRoom/controller/StudyRoomController.java
+++ b/backend/src/main/java/com/study/deposit/domain/studyRoom/controller/StudyRoomController.java
@@ -7,6 +7,7 @@ import com.study.deposit.domain.studyRoom.dao.StudyRoomDao;
 import com.study.deposit.domain.studyRoom.dao.UserStudyRoomDao;
 import com.study.deposit.domain.studyRoom.domain.StudyRoom;
 import com.study.deposit.domain.studyRoom.domain.UserStudyRoom;
+import com.study.deposit.domain.studyRoom.dto.EnterStudyRoomReqDto;
 import com.study.deposit.domain.studyRoom.dto.StudyRoomMakingReqDto;
 import com.study.deposit.domain.studyRoom.service.StudyRoomService;
 import com.study.deposit.domain.user.domain.Users;
@@ -72,20 +73,21 @@ public class StudyRoomController {
                 .body(CommonResponse.toResponse(CommonCode.OK,studyRoomService.getStudyRoomList()));
     }
 
-//    @Operation(summary = "스터디방 입장 api", description = "스터디방 입장시 요청하는 API")
-//    @ApiResponses(
-//            value = {
-//                    @ApiResponse(responseCode = "200", description = "정상 처리"),
-//                    @ApiResponse(responseCode = "401", description = "사용자 확인 불가"),
-//                    @ApiResponse(responseCode = "402", description = "방 입장을 위한 포인트 부족"),
-//            }
-//    )
-//    @GetMapping
-//    public ResponseEntity<CommonResponse> enterStudyRoom() {
-//        return ResponseEntity
-//                .status(HttpStatus.OK)
-//                .body(CommonResponse.toResponse(CommonCode.OK,studyRoomService.getStudyRoomList()));
-//    }
+    @Operation(summary = "스터디방 입장 api", description = "스터디방 입장시 요청하는 API")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "정상 처리"),
+                    @ApiResponse(responseCode = "401", description = "사용자 확인 불가"),
+                    @ApiResponse(responseCode = "402", description = "방 입장을 위한 포인트 부족"),
+            }
+    )
+    @PostMapping("/enter")
+    public ResponseEntity<CommonResponse> enterStudyRoom(@RequestBody @Valid EnterStudyRoomReqDto dto) {
+        studyRoomService.enterStudyRoom(dto.getId());
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(CommonResponse.toResponse(CommonCode.OK));
+    }
 
 
 }

--- a/backend/src/main/java/com/study/deposit/domain/studyRoom/domain/UserStudyRoom.java
+++ b/backend/src/main/java/com/study/deposit/domain/studyRoom/domain/UserStudyRoom.java
@@ -39,11 +39,11 @@ public class UserStudyRoom {
     private StudyRoomRole studyRoomRole;
 
     //호스트가 방을 만들때만 사용가능
-    public static UserStudyRoom toEntityForHost(StudyRoom studyRoom, Users host) {
+    public static UserStudyRoom toEntityForHost(StudyRoom studyRoom, Users host,StudyRoomRole studyRoomRole) {
         return UserStudyRoom.builder()
                 .studyRoom(studyRoom)
                 .users(host)
-                .studyRoomRole(StudyRoomRole.HOST)
+                .studyRoomRole(studyRoomRole)
                 .build();
     }
 

--- a/backend/src/main/java/com/study/deposit/domain/studyRoom/dto/EnterStudyRoomReqDto.java
+++ b/backend/src/main/java/com/study/deposit/domain/studyRoom/dto/EnterStudyRoomReqDto.java
@@ -1,0 +1,10 @@
+package com.study.deposit.domain.studyRoom.dto;
+
+import javax.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+public class EnterStudyRoomReqDto {
+    @NotNull
+    private Long id;
+}

--- a/backend/src/main/java/com/study/deposit/domain/studyRoom/dto/StudyRoomInfoResDto.java
+++ b/backend/src/main/java/com/study/deposit/domain/studyRoom/dto/StudyRoomInfoResDto.java
@@ -14,6 +14,8 @@ import org.springframework.format.annotation.DateTimeFormat;
 @Data
 public class StudyRoomInfoResDto {
     @NotNull
+    private Long id;
+    @NotNull
     private String title;
     @NotNull
     private List<String> hashTags;
@@ -39,15 +41,17 @@ public class StudyRoomInfoResDto {
     public static StudyRoomInfoResDto getEntity(StudyRoom studyRoom, List<HashTag> hashTags, Long currentOccupancy) {
         StudyRoomInfoResDto studyRoomInfoResDto = new StudyRoomInfoResDto();
         studyRoomInfoResDto.setTitle(studyRoom.getTitle());
+        studyRoomInfoResDto.setId(studyRoom.getId());
         studyRoomInfoResDto.setCapacity(studyRoom.getPersonCapacity());
         studyRoomInfoResDto.setAttendanceTime(studyRoom.getAttendanceTime());
         studyRoomInfoResDto.setEndDate(studyRoom.getEndDate());
         //해시태그
+        List<String> ownHashTags = new ArrayList<>();
         for (HashTag hashTag : hashTags) {
-            List<String> ownHashTags = new ArrayList<>();
             ownHashTags.add(hashTag.getTagName());
-            studyRoomInfoResDto.setHashTags(ownHashTags);
         }
+        studyRoomInfoResDto.setHashTags(ownHashTags);
+
         studyRoomInfoResDto.setCurrentOccupancy(currentOccupancy);
         studyRoomInfoResDto.setStartDate(studyRoom.getCreateDate().toLocalDate());
         studyRoomInfoResDto.setDeposit(studyRoom.getDeposit());

--- a/backend/src/main/java/com/study/deposit/domain/studyRoom/dto/StudyRoomMakingReqDto.java
+++ b/backend/src/main/java/com/study/deposit/domain/studyRoom/dto/StudyRoomMakingReqDto.java
@@ -12,6 +12,7 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Positive;
 import lombok.Data;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.lang.Nullable;
 
 @Data
 public class StudyRoomMakingReqDto {

--- a/backend/src/main/java/com/study/deposit/domain/user/domain/Users.java
+++ b/backend/src/main/java/com/study/deposit/domain/user/domain/Users.java
@@ -55,4 +55,10 @@ public class Users extends BaseTimeEntity implements Serializable {
         return this;
     }
 
+    //basetimeEntity때문에 overrride가 안됨
+    public  boolean isEqualUser(Users o) {
+        return this.getId().equals(o.getId());
+    }
+
+
 }

--- a/backend/src/main/java/com/study/deposit/global/common/code/studyroom/StudyRoomErrorCode.java
+++ b/backend/src/main/java/com/study/deposit/global/common/code/studyroom/StudyRoomErrorCode.java
@@ -5,7 +5,8 @@ import lombok.Getter;
 
 @Getter
 public enum StudyRoomErrorCode implements Code {
-    NOT_ENOUGH_POINT_FOR_DEPOSIT("STD001", "스터디방에 입장하기 위한 포인트가 부족합니다.(보증금보다 작은 포인트 보유)");
+    NOT_ENOUGH_POINT_FOR_DEPOSIT("STD001", "스터디방에 입장하기 위한 포인트가 부족합니다.(보증금보다 작은 포인트 보유)"),
+    ALREADY_ENTER_ROOM("STD002", "이미 입장한 스터디방입니다.");
     private String code;
     private String message;
 

--- a/backend/src/main/java/com/study/deposit/global/common/exception/studyroom/StudyRoomException.java
+++ b/backend/src/main/java/com/study/deposit/global/common/exception/studyroom/StudyRoomException.java
@@ -1,0 +1,13 @@
+package com.study.deposit.global.common.exception.studyroom;
+
+import com.study.deposit.global.common.code.Code;
+import com.study.deposit.global.common.exception.DefaultException;
+import org.springframework.http.HttpStatus;
+
+public class StudyRoomException extends DefaultException {
+
+
+    public StudyRoomException(Code code, HttpStatus httpStatus) {
+        super(code, httpStatus);
+    }
+}

--- a/backend/src/test/java/com/study/deposit/domain/hashTag/controller/HashTagControllerTest.java
+++ b/backend/src/test/java/com/study/deposit/domain/hashTag/controller/HashTagControllerTest.java
@@ -51,9 +51,11 @@ class HashTagControllerTest {
     @DisplayName("해시태그 생성 API")
     public void testCreateHashTag() throws Exception {
         String requestBody = "{\"tagName\":\"test\"}";
+        HashTag newHashTag = HashTag.builder().id(1L).tagName("test").build();
+        MakeHashTagReqDto dto = new MakeHashTagReqDto();
+        dto.setTagName("test");
 
-        doNothing().when(hashTagService).makeHashTag(ArgumentMatchers.any(MakeHashTagReqDto.class));
-
+        when(hashTagService.makeHashTag(dto)).thenReturn(newHashTag);
         mockMvc.perform(post("/api/v1/hashtag")
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)

--- a/backend/src/test/java/com/study/deposit/domain/studyRoom/domain/UserStudyRoomTest.java
+++ b/backend/src/test/java/com/study/deposit/domain/studyRoom/domain/UserStudyRoomTest.java
@@ -35,7 +35,7 @@ class UserStudyRoomTest {
                 .nickName("testNickName")
                 .build();
         //when
-        UserStudyRoom userStudyRoom = UserStudyRoom.toEntityForHost(testStudyRoom, testUser);
+        UserStudyRoom userStudyRoom = UserStudyRoom.toEntityForHost(testStudyRoom, testUser,StudyRoomRole.HOST);
         //then
         assertThat(userStudyRoom.getUsers()).isEqualTo(testUser);
         assertThat(userStudyRoom.getStudyRoom()).isEqualTo(testStudyRoom);

--- a/backend/src/test/java/com/study/deposit/domain/studyRoom/service/StudyRoomServiceTest.java
+++ b/backend/src/test/java/com/study/deposit/domain/studyRoom/service/StudyRoomServiceTest.java
@@ -2,6 +2,7 @@ package com.study.deposit.domain.studyRoom.service;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -30,6 +31,7 @@ import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -169,6 +171,25 @@ class StudyRoomServiceTest {
         assertEquals("testRoom1", result.get(0).getTitle());
         // Assert the properties of the second StudyRoomInfoResDto
         assertEquals("testRoom2", result.get(1).getTitle());
+    }
+
+    @Test
+    @DisplayName("스터디방 입장")
+    void enterStudyRoom_ShouldSaveUserToStudyRoom() {
+        // Mock dependencies
+        StudyRoom studyRoom = new StudyRoom();
+        when(studyRoomDao.findById(anyLong())).thenReturn(Optional.of(studyRoom));
+
+        Users user = new Users();
+        when(authService.getUser()).thenReturn(user);
+
+        // Call the method under test
+        studyRoomService.enterStudyRoom(123L);
+
+        // Verify the expected behavior
+        verify(studyRoomDao).findById(123L);
+        verify(authService).getUser();
+        // Add more assertions as needed
     }
 
 }

--- a/backend/src/test/java/com/study/deposit/domain/studyRoom/service/StudyRoomServiceTest.java
+++ b/backend/src/test/java/com/study/deposit/domain/studyRoom/service/StudyRoomServiceTest.java
@@ -10,7 +10,6 @@ import static org.mockito.Mockito.when;
 
 import com.study.deposit.domain.hashTag.domain.HashTag;
 import com.study.deposit.domain.hashTag.service.HashTagService;
-import com.study.deposit.domain.point.dao.PointRecordDao;
 import com.study.deposit.domain.point.domain.PaymentType;
 import com.study.deposit.domain.point.service.PointRecordService;
 import com.study.deposit.domain.studyRoom.dao.StudyRoomDao;
@@ -107,40 +106,6 @@ class StudyRoomServiceTest {
         return dto;
     }
 
-    @Test
-    @DisplayName("스터디방 입장 로직-실패 케이스")
-    public void testEnterStudyRoom_InsufficientFunds() {
-        Users hostUser = makeTestHostUser();
-
-        when(authService.getUser()).thenReturn(hostUser);
-        when(pointRecordService.getSumRecordByUser(hostUser)).thenReturn(1000L);
-
-        Long deposit = 5000L;
-
-        // Ensure that the PaymentException is thrown with the expected error code and status
-        Assertions.assertThrows(
-                PaymentException.class,
-                () -> {
-                    studyRoomService.enterStudyRoom(deposit);
-                }
-        );
-        verify(pointRecordService, never()).insertRecord(hostUser, deposit, PaymentType.PURCHASE);
-    }
-
-    @Test
-    @DisplayName("스터디방 입장 로직-성공 케이스")
-    public void testEnterStudyRoom_Valid() {
-        Users hostUser = makeTestHostUser();
-
-        when(authService.getUser()).thenReturn(hostUser);
-        when(pointRecordService.getSumRecordByUser(hostUser)).thenReturn(1000L);
-
-        Long deposit = 500L;
-        studyRoomService.enterStudyRoom(deposit);
-
-        // Verify that the insertRecord method was called with the correct arguments
-        verify(pointRecordService, times(1)).insertRecord(hostUser, deposit, PaymentType.PURCHASE);
-    }
 
     @Test
     @DisplayName("스터디방 전체 조회")

--- a/front/src/components/study_room/HashTag.vue
+++ b/front/src/components/study_room/HashTag.vue
@@ -69,6 +69,7 @@ export default {
         )
         .then((response) => {
           this.myTags.push(response.data.data);
+          this.$emit('updateHashTags', this.myTags);
           this.inputText = "";
         })
         .catch((error) => {

--- a/front/src/components/study_room/MainStudyList.vue
+++ b/front/src/components/study_room/MainStudyList.vue
@@ -102,19 +102,29 @@ export default {
       this.isModalOpen = false;
     },
     enterRoom() {
-      if (this.usersPoint < this.selectedStudyRoom.deposit) {
-        axios
-          .get(`${import.meta.env.VITE_API_URI}/users`, {
-            withCredentials: true, // Include cookies in the request
-          })
-          .then((response) => {
-            if (response.status === 200) {
-              this.usersPoint = response.data.data.sumOfChargeAmount;
-            }
-          })
-          .catch((error) => {
+      if (this.usersPoint >= this.selectedStudyRoom.deposit) {
+        axios({
+        method: "post", // [요청 타입]
+        url: `${import.meta.env.VITE_API_URI}/studyroom/enter`, // [요청 주소]
+        data: JSON.stringify({
+          id:this.selectedStudyRoom.id
+        }), // [요청 데이터]
+
+        headers: {
+          "Content-Type": "application/json; charset=utf-8",
+        },
+        withCredentials: true,
+      })
+        .then((response) => {
+          if (response.status === 200) {
+            this.$router.push({ path: "/studyroom/list" });
+          } else {
             this.$router.push({ path: "/error" });
-          });
+          }
+        })
+        .catch(function (error) {
+          this.$router.push({ path: "/error" });
+        });
       }else{
         this.insufficientPoints=true;
       }

--- a/front/src/components/study_room/PostStudyRoom.vue
+++ b/front/src/components/study_room/PostStudyRoom.vue
@@ -99,7 +99,7 @@ export default {
       title: "",
       selectedTime: "",
       attendanceTime: "",
-      hashTags: "",
+      hashTags: [],
     };
   },
   methods: {
@@ -128,7 +128,7 @@ export default {
           endDate: this.endDate,
           personCapacity: this.personCapacity,
           deposit: this.deposit,
-          hashTags: this.hashTags,
+          hashTags: this.hashTags
         }), // [요청 데이터]
 
         headers: {

--- a/front/src/components/study_room/PostStudyRoom.vue
+++ b/front/src/components/study_room/PostStudyRoom.vue
@@ -138,7 +138,7 @@ export default {
       })
         .then((response) => {
           if (response.status === 201) {
-            this.$router.push({ path: "/studyroom/success" });
+            this.$router.push({ path: "/studyroom/list" });
           } else {
             this.$router.push({ path: "/error" });
           }


### PR DESCRIPTION
## 🌿 이슈 번호 : #39 

<br>

## 📝 PR 유형 
- [x] 새로운 feature 추가
- [x] feature 수정 (기능 업데이트, 버그 수정 등)
- [ ] 관련 문서 추가
- [ ] 관련 문서 수정

<br>

## 🧑‍💻 작업 내용 
- 해시태그 1개 새롭게 등록하는경우 에러 처리 수정
- 해시태그 비어있는경우 등록안되는경우 수정
- 스터디방 입장에 필요한 API 생성
 - 입장시 보증금 없는경우 에러처리
 - 자신이 속한방을 한번더 입장요청시 에러처리
- 스터디방 조회시 자신이 속한 방, 꽉찬방 제외

